### PR TITLE
Remove prints

### DIFF
--- a/stackongo/auth.go
+++ b/stackongo/auth.go
@@ -13,7 +13,7 @@ type authError struct {
 
 var auth_url string = "https://stackexchange.com/oauth/access_token"
 
-// AuthURL returns the URL to redirect the user for authentication 
+// AuthURL returns the URL to redirect the user for authentication
 // It accepts the following arguments
 // client_id - Your App's registered ID
 // redirect_uri - URI to redirect after authentication
@@ -58,7 +58,7 @@ func ObtainAccessToken(client_id, client_secret, code, redirect_uri string) (out
 
 		error = errors.New(collection.Error["type"] + ": " + collection.Error["message"])
 	} else {
-		// if not process the output 
+		// if not process the output
 		bytes, err2 := ioutil.ReadAll(response.Body)
 
 		if err2 != nil {

--- a/stackongo/auth_test.go
+++ b/stackongo/auth_test.go
@@ -2,14 +2,20 @@ package stackongo
 
 import (
 	"net/url"
+	"reflect"
 	"testing"
 )
 
 func TestAuthURL(t *testing.T) {
 	result_uri, _ := url.Parse(AuthURL("abc", "www.my_app.com", map[string]string{"state": "test", "scope": "read_inbox,no_expiry"}))
 
-	if result_uri.Query().Encode() != "state=test&scope=read_inbox%2Cno_expiry&redirect_uri=www.my_app.com&client_id=abc" {
-		print(result_uri.Query().Encode())
+	if !reflect.DeepEqual(result_uri.Query(), url.Values{
+		"state":        []string{"test"},
+		"scope":        []string{"read_inbox,no_expiry"},
+		"redirect_uri": []string{"www.my_app.com"},
+		"client_id":    []string{"abc"},
+	}) {
+		t.Log(result_uri.Query().Encode())
 		t.Error("URL doesn't match")
 	}
 }


### PR DESCRIPTION
Its a bit jarring to have an error appear (without a new line). Let the error be printed by the end user instead.